### PR TITLE
CMS5 compatibility code so far

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+import threading
+def call(cmd, ignore_return_code=False):
+   print('Running: \n' + cmd + '\n')
+   ps = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+   returncode = ps.wait()
+   stdout = ps.communicate()[0]
+   if returncode != 0 and not ignore_return_code:
+       print >> sys.stderr, ('Error: command "{}" failed: {}'.format(cmd, stdout))
+       sys.exit(returncode)
+   else:
+       return stdout
+def docker_install(hostnm):
+    self.call("ssh $hostnm curl -sSL https://get.docker.com | sh")
+    
+def swarm_install(hostnm,hosttyp):
+    if hosttyp == "Master":
+               self.call("sudo docker swarm init --advertise-addr " + hostnm)
+    else:
+        jointkn = self.call("sudo docker swarm join-token worker")
+        testsh = "ssh $hostnm  + self.call(jointkn)"
+    self.call(testsh)
+def pull(self):
+   nodes = self.call("docker node ls | grep Ready | awk -F'[[:space:]][[:space:]]+' '{print $2}'").rstrip().split('\n')

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup
+
+setup(name='Dockerswarm',
+      version='1.0',
+      description='Rasberry Pi Docker Swarm Cluster',
+      author='Uma M Kugan',
+	  author='Andres Castro Benavides',
+      author_email='umakugan@iu.edu',
+      author_email='acastrob@iu.edu',
+	  url='https://github.com/cloudmesh-community/hid-sp18-709/tree/master/project-code',
+      packages=['dockerswarm'],
+     )
+

--- a/tools.yml
+++ b/tools.yml
@@ -1,0 +1,20 @@
+---
+name:Raspberry Pi
+    description:Small single board computer developed for research and prototyping
+    url:raspberrypi.org
+keywords:>
+    -raspberry pi
+    -
+featuresused:>
+    - 
+    -
+
+name:Docker Containers
+    description:Container platform that works on hybrid environments 
+    url:docker.com/
+keywords:>
+    - Docker
+    - Container
+featuresused:>
+    - Swarm mode
+    -


### PR DESCRIPTION
These document -in particular, docker.py and setup.py- are meant to be used to define the functions to deploy and configure a docker swarm on a RPi cluster -or any other Debian Based set of nodes- using cloud mesh (CMS5).
We have been able to run the code in a command line and deploy and configure it successfully on the RPi's and a test virtual environment comprising 3 Ubuntu 15.1 nodes.